### PR TITLE
自動ビルドテストをするようにしました

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: korosuke613/etrobo-docker
+    working_directory: /home/build
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: move str directory and cd src
+          command: |
+            mv str /home/hrp2/sdk/workspace/
+            mv -T /home/hrp2/sdk/workspace/str/ /home/hrp2/sdk/workspace/src/ 
+
+      - run:
+          name: makeRight
+          command: |
+            cd /home/hrp2/sdk/workspace/src/
+            ./makeRight.sh
+      - run:
+          name: makeLeft
+          command: |
+            cd /home/hrp2/sdk/workspace/src/ 
+            ./makeLeft.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: required
+dist: trusty
+sudo: false
+language: cpp
 
 service:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+service:
+  - docker
+
+script:
+ - cd str
+ - docker run --rm -it -v $PWD:/home/hrp2/sdk/workspace/src korosuke613/etrobo-docker makeRight
+ - docker run --rm -it -v $PWD:/home/hrp2/sdk/workspace/src korosuke613/etrobo-docker makeLeft
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 sudo: false
-language: cpp
+language: none
 
 service:
   - docker

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # etrobocon2018
+[![Build Status](https://travis-ci.org/KatLab-MiyazakiUniv/etrobocon2018.svg?branch=master)](https://travis-ci.org/KatLab-MiyazakiUniv/etrobocon2018)
+[![codecov](https://codecov.io/gh/KatLab-MiyazakiUniv/etrobocon2018/branch/master/graph/badge.svg)](https://codecov.io/gh/KatLab-MiyazakiUniv/etrobocon2018)
 
 ## コミット方法
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # etrobocon2018
-[![Build Status](https://travis-ci.org/KatLab-MiyazakiUniv/etrobocon2018.svg?branch=master)](https://travis-ci.org/KatLab-MiyazakiUniv/etrobocon2018)
+[![Build Status](https://travis-ci.org/KatLab-MiyazakiUniv/etrobocon2018.svg?branch=master)](https://travis-ci.org/KatLab-MiyazakiUniv/etrobocon2018) [![CircleCI](https://circleci.com/gh/KatLab-MiyazakiUniv/etrobocon2018/tree/master.svg?style=svg)](https://circleci.com/gh/KatLab-MiyazakiUniv/etrobocon2018/tree/master)
+
 [![codecov](https://codecov.io/gh/KatLab-MiyazakiUniv/etrobocon2018/branch/master/graph/badge.svg)](https://codecov.io/gh/KatLab-MiyazakiUniv/etrobocon2018)
 
 ## コミット方法


### PR DESCRIPTION
# 変更点
travis ciとcircle ciで、push時にビルドテストを行うようにした

# メリット
ビルドに失敗するプログラムのマージを未然に防ぐ

# その他
今回、ソースコードのテストは行っていません。あくまで、ビルドのテストのみ