### PR TITLE
googletestのバグがfixされたみたいなので、リポジトリを最新に修正。

### DIFF
--- a/str/apps/ext/gtest/CMakeLists.txt
+++ b/str/apps/ext/gtest/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG d5266326752f0a1dadbd310932d8f4fd8c3c5e7d
+    #GIT_TAG d5266326752f0a1dadbd310932d8f4fd8c3c5e7d
     CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
     -DCMAKE_CXX_FLAGS=${MSVC_COMPILER_DEFS}


### PR DESCRIPTION
# 変更点
googletest時に、最新のリポジトリを取得するようにした。

# メリット
最新のgoogletestを使用できる。

# その他
googletestのバグが修正されたみたいです。https://github.com/google/googletest/issues/1711