### PR TITLE
カラーセンサより、色を推定するDistinguisherクラスを作成しました。

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
                 "cstdint": "cpp",
                 "functional": "cpp",
                 "tuple": "cpp",
-                "utility": "cpp"
+                "utility": "cpp",
+                "random": "cpp"
         }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ file(GLOB SRC_FILES ${SOURCE_DIR}/Pid.cpp
     ${SOURCE_DIR}/LeftCourse.cpp
     ${SOURCE_DIR}/EtRobocon2018.cpp
     ${SOURCE_DIR}/UserInterface.cpp
+    ${SOURCE_DIR}/Distinguisher.cpp
     )
 add_library(${PROJECT_LIB_NAME} ${SRC_FILES})
 

--- a/scripts/color_check/color_check.cpp
+++ b/scripts/color_check/color_check.cpp
@@ -1,0 +1,88 @@
+/**
+ * ファイル名 : app.c
+ *
+ * 概要 : ETロボコンのTOPPERS/HRP2用Cサンプルプログラム
+ *
+ * 注記 : Bluetooth通信リモートスタート機能付き
+ */
+
+#include "Controller.h"
+#include "Distinguisher.h"
+#include "app.h"
+#include "ev3api.h"
+#include "util.h"
+
+#if defined(BUILD_MODULE)
+#include "module_cfg.h"
+#else
+#include "kernel_cfg.h"
+#endif
+
+#define DEBUG
+
+#ifdef DEBUG
+#define _debug(x) (x)
+#else
+#define _debug(x)
+#endif
+
+static int g_bluetooth_command = 0;  // Bluetoothコマンド 1:リモートスタート
+static FILE* g_bluetooth = NULL;     // Bluetoothファイルハンドル
+
+/* メインタスク */
+void main_task(intptr_t unused)
+{
+  /* Open Bluetooth file */
+  g_bluetooth = ev3_serial_open_file(EV3_SERIAL_BT);
+  assert(g_bluetooth != NULL);
+
+  /* Bluetooth通信タスクの起動 */
+  act_tsk(BT_TASK);
+
+  msg_f("ET-Robocon2018", 1);
+  msg_f(" create from github.com/korosuke613/etrobocon2018", 2);
+
+  Controller controller;
+  Distinguisher distinguisher{ controller };
+  const char* color_name[7] = { "NONE", "BLACK", "WHITE", "RED", "BLUE", "YELLOW", "GREEN" };
+  while(1) {
+    if(controller.buttonIsPressedBack()) {
+      break;
+    }
+    int result = static_cast<int>(distinguisher.getColor());
+    controller.printDisplay(4, "RGB: %d, %d, %d", distinguisher.raw_color.r,
+                            distinguisher.raw_color.g, distinguisher.raw_color.b);
+    controller.printDisplay(5, "Color Distance: %lf", distinguisher.last_distance);
+    controller.printDisplay(6, "Color Number: %d", result);
+    controller.printDisplay(7, "Color Name: %s", color_name[result]);
+
+    controller.tslpTsk(4);
+  }
+
+  ter_tsk(BT_TASK);
+  fclose(g_bluetooth);
+
+  ext_tsk();
+}
+
+/**
+ * 概要 : Bluetooth通信によるリモートスタート。
+ *        Tera Termなどのターミナルソフトから、
+ *        ASCIIコードで1を送信すると、リモートスタートする。
+ * 引数 : unused
+ * 返り値 : なし
+ */
+void bt_task(intptr_t unused)
+{
+  while(1) {
+    uint8_t c = fgetc(g_bluetooth); /* 受信 */
+    switch(c) {
+      case '1':
+        g_bluetooth_command = 1;
+        break;
+      default:
+        break;
+    }
+    fputc(c, g_bluetooth); /* エコーバック */
+  }
+}

--- a/scripts/color_check/make.sh
+++ b/scripts/color_check/make.sh
@@ -1,0 +1,10 @@
+mv ../../str/app.cpp ../../str/app.cpp.bak
+
+cp color_check.cpp ../../str/app.cpp
+
+cd ../../str
+docker run -it --rm -v "$(pwd)":/home/hrp2/sdk/workspace/product korosuke613/etrobo-docker makeLeft
+cd ../scripts/color_check
+mv ../../str/app_left ../../str/app_color_check
+
+mv ../../str/app.cpp.bak ../../str/app.cpp

--- a/str/Makefile.inc
+++ b/str/Makefile.inc
@@ -16,6 +16,7 @@ Emoter.o \
 NormalCourse.o \
 FirstCode.o \
 Controller.o \
+Distinguisher.o
 
 ifeq ($(side),right)
     APPL_CXXOBJS += RightNormalCourse.o \

--- a/str/apps/include/Controller.h
+++ b/str/apps/include/Controller.h
@@ -57,6 +57,7 @@ class Controller {
   bool buttonIsPressedEnter();
   void tslpTsk(int16_t time);  // 4msec周期起動
   void printDisplay(int8_t row, const char* format, ...);
+  void getRawColor(uint16_t& r, uint16_t& g, uint16_t& b);
 
  private:
   rgb_raw_t rgb;

--- a/str/apps/include/Distinguisher.h
+++ b/str/apps/include/Distinguisher.h
@@ -1,0 +1,44 @@
+#ifndef __DISTINGUISHER_H__
+#define __DISTINGUISHER_H__
+
+#include "Controller.h"
+#include <cstdint>
+
+enum struct Color { NONE, BLACK, WHITE, RED, BLUE, YELLOW, GREEN };
+
+struct Rgb {
+  Color color;
+  std::uint16_t r;
+  std::uint16_t g;
+  std::uint16_t b;
+};
+
+class DistinguisherTest;
+
+class Distinguisher {
+  friend class DistinguisherTest;
+
+ public:
+  Distinguisher() = default;
+  explicit Distinguisher(Controller controller_) : controller(controller_) {}
+  Color getColor();
+  Color distingishColor();
+  void setRawColor2Rgb();
+  void judgement(const Rgb& rgb, double& min);
+  double distanceColor(Rgb target_color);
+  double last_distance = 0.0;
+  double threshold_distance = 400;
+
+ private:
+  Controller controller;
+  Color color = Color::NONE;
+  Rgb raw_color = { Color::NONE, 0, 0, 0 };
+  const Rgb RED = { Color::RED, 255, 0, 0 };
+  const Rgb BLUE = { Color::BLUE, 0, 0, 255 };
+  const Rgb GREEN = { Color::GREEN, 0, 255, 0 };
+  const Rgb YELLOW = { Color::YELLOW, 255, 255, 0 };
+  const Rgb BLACK = { Color::BLACK, 0, 0, 0 };
+  const Rgb WHITE = { Color::WHITE, 255, 255, 255 };
+};
+
+#endif

--- a/str/apps/include/Distinguisher.h
+++ b/str/apps/include/Distinguisher.h
@@ -19,7 +19,6 @@ class Distinguisher {
   friend class DistinguisherTest;
 
  public:
-  Distinguisher() = default;
   explicit Distinguisher(Controller controller_) : controller(controller_) {}
   Color getColor();
   Color distingishColor();

--- a/str/apps/include/Distinguisher.h
+++ b/str/apps/include/Distinguisher.h
@@ -28,17 +28,17 @@ class Distinguisher {
   double distanceColor(Rgb target_color);
   double last_distance = 0.0;
   double threshold_distance = 400;
+  Rgb raw_color = { Color::NONE, 0, 0, 0 };
 
  private:
   Controller controller;
   Color color = Color::NONE;
-  Rgb raw_color = { Color::NONE, 0, 0, 0 };
-  const Rgb RED = { Color::RED, 255, 0, 0 };
-  const Rgb BLUE = { Color::BLUE, 0, 0, 255 };
-  const Rgb GREEN = { Color::GREEN, 0, 255, 0 };
-  const Rgb YELLOW = { Color::YELLOW, 255, 255, 0 };
-  const Rgb BLACK = { Color::BLACK, 0, 0, 0 };
-  const Rgb WHITE = { Color::WHITE, 255, 255, 255 };
+  const Rgb RED = { Color::RED, 112, 13, 9 };
+  const Rgb BLUE = { Color::BLUE, 18, 47, 50 };
+  const Rgb GREEN = { Color::GREEN, 24, 77, 13 };
+  const Rgb YELLOW = { Color::YELLOW, 116, 120, 15 };
+  const Rgb BLACK = { Color::BLACK, 14, 19, 5 };
+  const Rgb WHITE = { Color::WHITE, 128, 158, 93 };
 };
 
 #endif

--- a/str/apps/src/Controller.cpp
+++ b/str/apps/src/Controller.cpp
@@ -29,27 +29,40 @@ bool Controller::buttonIsPressedEnter()
 {
   return ev3_button_is_pressed(ENTER_BUTTON);
 }
+
 bool Controller::buttonIsPressedUp()
 {
   return ev3_button_is_pressed(UP_BUTTON);
 }
+
 bool Controller::buttonIsPressedDown()
 {
   return ev3_button_is_pressed(DOWN_BUTTON);
 }
+
 bool Controller::buttonIsPressedRight()
 {
   return ev3_button_is_pressed(RIGHT_BUTTON);
 }
+
 bool Controller::buttonIsPressedLeft()
 {
   return ev3_button_is_pressed(LEFT_BUTTON);
 }
+
 int16_t Controller::getBrightness()
 {
   colorSensor.getRawColor(rgb);
   int16_t luminance = 0.298912 * rgb.r + 0.586611 * rgb.g + 0.114478 * rgb.b;
   return luminance;
+}
+
+void Controller::getRawColor(uint16_t& r, uint16_t& g, uint16_t& b)
+{
+  colorSensor.getRawColor(rgb);
+  r = rgb.r;
+  g = rgb.g;
+  b = rgb.b;
 }
 
 void Controller::tslpTsk(int16_t time)

--- a/str/apps/src/Distinguisher.cpp
+++ b/str/apps/src/Distinguisher.cpp
@@ -1,0 +1,57 @@
+#include "Distinguisher.h"
+#include <cmath>
+
+Color Distinguisher::getColor()
+{
+  setRawColor2Rgb();
+  auto color = distingishColor();
+  return color;
+}
+
+void Distinguisher::setRawColor2Rgb()
+{
+  std::uint32_t total_r, total_g, total_b;
+  std::int8_t times = 10;
+
+  total_r = total_g = total_b = 0;
+  for(int i = 0; i < times; i++) {
+    controller.getRawColor(raw_color.r, raw_color.g, raw_color.b);
+    total_r += raw_color.r;
+    total_g += raw_color.g;
+    total_b += raw_color.b;
+  }
+  raw_color.r = total_r / times;
+  raw_color.g = total_g / times;
+  raw_color.b = total_b / times;
+}
+
+Color Distinguisher::distingishColor()
+{
+  color = Color::NONE;
+  double min_distance = threshold_distance;
+
+  judgement(RED, min_distance);
+  judgement(BLUE, min_distance);
+  judgement(YELLOW, min_distance);
+  judgement(GREEN, min_distance);
+  judgement(WHITE, min_distance);
+  judgement(BLACK, min_distance);
+  return color;
+}
+
+void Distinguisher::judgement(const Rgb& rgb, double& min)
+{
+  double tmp = last_distance = distanceColor(rgb);
+  if(tmp < min) {
+    color = rgb.color;
+    min = tmp;
+  }
+}
+
+double Distinguisher::distanceColor(Rgb target_color)
+{
+  std::uint16_t pow_r = std::pow(raw_color.r - target_color.r, 2);
+  std::uint16_t pow_g = std::pow(raw_color.g - target_color.g, 2);
+  std::uint16_t pow_b = std::pow(raw_color.b - target_color.b, 2);
+  return std::sqrt(pow_r + pow_g + pow_b);
+}

--- a/str/apps/test/DistinguisherTest.cpp
+++ b/str/apps/test/DistinguisherTest.cpp
@@ -1,0 +1,100 @@
+/**
+ * DistinguisherTest.cpp
+ */
+
+/* コンパイル(平木場)
+$ g++-7 DistinguisherTest.cpp ../src/Distinguisher.cpp gtest_main.o gtest-all.o -I../include
+-I../../googletest/googletest/include
+*/
+
+#include "Distinguisher.h"  // このヘッダファイルのcppファイルをテスト
+#include <gtest/gtest.h>
+
+class DistinguisherTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {}
+  Controller controller;
+  Distinguisher d{ controller };
+  void setMockRgb(std::uint16_t r, std::uint16_t g, std::uint16_t b)
+  {
+    d.controller.setMockRgb(r, g, b);
+  }
+  Rgb getRed() { return d.RED; }
+};
+
+TEST_F(DistinguisherTest, getColorRedTest1)
+{
+  setMockRgb(255, 0, 0);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::RED);
+}
+
+TEST_F(DistinguisherTest, getColorRedTest2)
+{
+  setMockRgb(220, 62, 56);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::RED);
+}
+
+TEST_F(DistinguisherTest, getColorBlueTest1)
+{
+  setMockRgb(0, 0, 255);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::BLUE);
+}
+
+TEST_F(DistinguisherTest, getColorBlueTest2)
+{
+  setMockRgb(40, 106, 165);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::BLUE);
+}
+
+TEST_F(DistinguisherTest, getColorYellowTest1)
+{
+  setMockRgb(255, 255, 0);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::YELLOW);
+}
+
+TEST_F(DistinguisherTest, getColorYellowTest2)
+{
+  setMockRgb(255, 229, 18);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::YELLOW);
+}
+
+TEST_F(DistinguisherTest, getColorGreenTest1)
+{
+  setMockRgb(0, 255, 0);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::GREEN);
+}
+
+TEST_F(DistinguisherTest, getColorGreenTest2)
+{
+  setMockRgb(22, 167, 72);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::GREEN);
+}
+
+TEST_F(DistinguisherTest, getColorWhiteTest)
+{
+  setMockRgb(255, 255, 255);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::WHITE);
+}
+
+TEST_F(DistinguisherTest, getColorBlackTest)
+{
+  setMockRgb(0, 0, 0);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::BLACK);
+}
+
+TEST_F(DistinguisherTest, distanceColorRedTest1)
+{
+  setMockRgb(255, 0, 0);
+  d.setRawColor2Rgb();
+  d.distanceColor(getRed());
+}

--- a/str/apps/test/DistinguisherTest.cpp
+++ b/str/apps/test/DistinguisherTest.cpp
@@ -29,9 +29,18 @@ TEST_F(DistinguisherTest, getColorRedTest1)
   ASSERT_EQ(result, Color::RED);
 }
 
+/*
 TEST_F(DistinguisherTest, getColorRedTest2)
 {
   setMockRgb(220, 62, 56);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::RED);
+}
+*/
+
+TEST_F(DistinguisherTest, getColorRedTest3)
+{
+  setMockRgb(112, 13, 9);
   Color result = d.getColor();
   ASSERT_EQ(result, Color::RED);
 }
@@ -43,13 +52,23 @@ TEST_F(DistinguisherTest, getColorBlueTest1)
   ASSERT_EQ(result, Color::BLUE);
 }
 
+/*
 TEST_F(DistinguisherTest, getColorBlueTest2)
 {
   setMockRgb(40, 106, 165);
   Color result = d.getColor();
   ASSERT_EQ(result, Color::BLUE);
 }
+*/
 
+TEST_F(DistinguisherTest, getColorBlueTest3)
+{
+  setMockRgb(18, 47, 50);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::BLUE);
+}
+
+/*
 TEST_F(DistinguisherTest, getColorYellowTest1)
 {
   setMockRgb(255, 255, 0);
@@ -63,13 +82,23 @@ TEST_F(DistinguisherTest, getColorYellowTest2)
   Color result = d.getColor();
   ASSERT_EQ(result, Color::YELLOW);
 }
+*/
 
+TEST_F(DistinguisherTest, getColorYellowTest3)
+{
+  setMockRgb(116, 120, 15);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::YELLOW);
+}
+
+/*
 TEST_F(DistinguisherTest, getColorGreenTest1)
 {
   setMockRgb(0, 255, 0);
   Color result = d.getColor();
   ASSERT_EQ(result, Color::GREEN);
 }
+*/
 
 TEST_F(DistinguisherTest, getColorGreenTest2)
 {
@@ -78,16 +107,37 @@ TEST_F(DistinguisherTest, getColorGreenTest2)
   ASSERT_EQ(result, Color::GREEN);
 }
 
-TEST_F(DistinguisherTest, getColorWhiteTest)
+TEST_F(DistinguisherTest, getColorGreenTest3)
+{
+  setMockRgb(24, 77, 13);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::GREEN);
+}
+
+TEST_F(DistinguisherTest, getColorWhiteTest1)
 {
   setMockRgb(255, 255, 255);
   Color result = d.getColor();
   ASSERT_EQ(result, Color::WHITE);
 }
 
-TEST_F(DistinguisherTest, getColorBlackTest)
+TEST_F(DistinguisherTest, getColorWhiteTest2)
+{
+  setMockRgb(128, 158, 93);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::WHITE);
+}
+
+TEST_F(DistinguisherTest, getColorBlackTest1)
 {
   setMockRgb(0, 0, 0);
+  Color result = d.getColor();
+  ASSERT_EQ(result, Color::BLACK);
+}
+
+TEST_F(DistinguisherTest, getColorBlackTest2)
+{
+  setMockRgb(14, 19, 5);
   Color result = d.getColor();
   ASSERT_EQ(result, Color::BLACK);
 }

--- a/str/apps/test/MockController.h
+++ b/str/apps/test/MockController.h
@@ -1,7 +1,9 @@
 #ifndef __CONTROLLER__
 #define __CONTROLLER__
 
+#include <cstdint>
 #include <cstdlib>
+#include <iostream>
 
 class Motor {
  public:
@@ -37,7 +39,7 @@ class Controller {
   ColorSensor colorSensor;
 
   int noteFs6 = 0;
-  Controller() {}
+  Controller() { mock_r = mock_g = mock_b = 0; }
   void speakerSetVolume(int volume){};
   void ledSetColorOrange(){};
   void ledSetColorGreen(){};
@@ -50,6 +52,14 @@ class Controller {
       return true;
     }
     return false;
+  };
+  void getRawColor(std::uint16_t& r, std::uint16_t& g, std::uint16_t& b)
+  {
+    r = mock_r;
+    g = mock_g;
+    b = mock_b;
+
+    return;
   };
   bool buttonIsPressedUp() { return false; };
   bool buttonIsPressedDown() { return false; };
@@ -75,5 +85,12 @@ class Controller {
   int exitCounter = 0;
   int exitCountLimit = 1000;
   int brightness = 0;
+  std::uint16_t mock_r, mock_g, mock_b;
+  void setMockRgb(std::uint16_t r, std::uint16_t g, std::uint16_t b)
+  {
+    mock_r = r;
+    mock_g = g;
+    mock_b = b;
+  }
 };
 #endif


### PR DESCRIPTION
# 変更点
Distinguisherクラスの追加。

# メリット
標準APIに存在する色を推定する関数は余り精度が良くありません。
なので、センサから取得したRGB情報と各色（赤、青、黄、緑、白、黒）を3次元空間上で距離を取り、一番近しい色を求めます。
余計な色を含まないため、精度が（元のAPIのより）高いです。

# その他
実機での確認は不十分です。

## 2018/08/24追記
実機でコースを使って確認したところ、設定していたRGBとかけ離れていたため、実際のコースのRGBを計り、設定しているRGBを修正しました。ほとんどの場合で、正しい色を識別できます。
しかし、黄色のブロックに近づいている途中で一瞬赤色のブロックだと判断してしまいます。