### PR TITLE
feat: 初期位置コードデコーダークラスを作成

### DIFF
--- a/str/apps/include/InitialPositionCodeDecoder.h
+++ b/str/apps/include/InitialPositionCodeDecoder.h
@@ -1,0 +1,82 @@
+/**
+ * @file InitialPositionCodeDecoder.h
+ * @brief 初期位置コードデコーダークラス
+ * @author Keisuke MORI
+ */
+#ifndef __INITIAL_POSITION_CODE_DECODER__
+#define __INITIAL_POSITION_CODE_DECODER__
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * <p> 5桁から6桁の初期位置コードを初期の位置コードリストにデコードするクラス </p>
+ *
+ * <p> Example </p>
+ *
+ * <pre>
+ *     {@code
+ *     InitialPositionCodeDecoder ipcd;
+ *     std::int32_t initialPositionCode = 74840; // = 1*16^4 + 2*16^3 + 4*16^2 + 5*16^1 + 8
+ *
+ *     ipcd.decode(initialPositionCode);
+ *
+ *     std::vector<std::int8_t> decodedColorBlockCodeList = ipcd.getInitialPositionCodeList(); // = {1, 2, 4, 5}
+ *     std::int8_t decodedPowerBlockCode = ipcd.getInitialPositionPowerBlockCode(); // = 8
+ *     }
+ * </pre>
+ */
+class InitialPositionCodeDecoder {
+ public:
+  /**
+   * <p> 初期位置コードをデコードする </p>
+   *
+   * @param code 初期位置コード <br> 0未満はこのクラスで定義している初期値を返す
+   */
+  void decode(std::int32_t code);
+
+  /**
+   * <p> 初期位置コードを取得する </p>
+   *
+   * @return 初期位置コード
+   */
+  std::int32_t getInitialPositionCode();
+
+  /**
+   * <p> 初期の位置コードリストを取得する </p>
+   *
+   * @return 初期の位置コードリスト
+   */
+  std::vector<std::int8_t> getInitialPositionCodeList();
+
+  /**
+   * <p> パワーブロックの初期の位置コードを取得する </p>
+   *
+   * <p>
+   * パワーブロックの初期位置は、1～8のみを取る。
+   * 計算外の場合は0を返す。
+   * 計算上、1～15までの値を取る可能性はあるが、9以上の場合は動作未検証である。
+   * </p>
+   *
+   * @return パワーブロックの初期の位置コード <br> 1~8のみ、 {@link #decode(std::int32_t)} の実行前は0を返す
+   */
+  std::int8_t getInitialPositionPowerBlockCode();
+
+ private:
+  /**
+   * 初期位置コード
+   */
+  std::int32_t initialPositionCode;
+
+  /**
+   * 初期の位置コードリスト
+   */
+  std::vector<std::int8_t> initialPositionCodeList = {0, 0, 0, 0};
+
+  /**
+   * パワーブロックの初期位置コード
+   */
+  std::int8_t initialPositionPowerBlockCode = 0;
+};
+
+#endif

--- a/str/apps/src/InitialPositionCodeDecoder.cpp
+++ b/str/apps/src/InitialPositionCodeDecoder.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file InitialPositionCodeDecoder.cpp
+ * @brief InitialPositionCodeDecoderクラスの関数を定義
+ * @author Keisuke MORI
+ */
+
+#include "InitialPositionCodeDecoder.h"
+
+void InitialPositionCodeDecoder::decode(std::int32_t code) {
+  if (code < 0) return;
+
+  std::int8_t remainder = 0;
+  initialPositionCode = code;
+  std::int32_t sumCurrentCode = 0;
+  std::int32_t codeBeforeDecoded = 0;
+
+  std::vector<std::int32_t> power16 = {1, 16, 16*16, 16*16*16, 16*16*16*16};
+
+  remainder = code % power16[4] % power16[3] % power16[2] % power16[1];
+  initialPositionPowerBlockCode = remainder;
+  sumCurrentCode = remainder;
+
+  codeBeforeDecoded = (code - sumCurrentCode) % power16[4] % power16[3] % power16[2];
+  initialPositionCodeList[3] = codeBeforeDecoded / power16[1];
+  sumCurrentCode += codeBeforeDecoded;
+
+  codeBeforeDecoded = (code - sumCurrentCode) % power16[4] % power16[3];
+  initialPositionCodeList[2] = codeBeforeDecoded / power16[2];
+  sumCurrentCode += codeBeforeDecoded;
+
+  codeBeforeDecoded = (code - sumCurrentCode) % power16[4];
+  initialPositionCodeList[1] = codeBeforeDecoded / power16[3];
+  sumCurrentCode += codeBeforeDecoded;
+
+  codeBeforeDecoded = (code - sumCurrentCode);
+  initialPositionCodeList[0] = codeBeforeDecoded / power16[4];
+}
+
+std::int32_t InitialPositionCodeDecoder::getInitialPositionCode() {
+  return initialPositionCode;
+}
+
+std::vector<std::int8_t> InitialPositionCodeDecoder::getInitialPositionCodeList() {
+  return initialPositionCodeList;
+}
+
+std::int8_t InitialPositionCodeDecoder::getInitialPositionPowerBlockCode() {
+  return initialPositionPowerBlockCode;
+}

--- a/str/apps/test/InitialPositionCodeDecoderTest.cpp
+++ b/str/apps/test/InitialPositionCodeDecoderTest.cpp
@@ -1,0 +1,149 @@
+/**
+ * InitialPositionCodeDecoderTest.cpp
+ */
+
+/* コンパイル(平木場)
+$ g++-7 InitialPositionCodeDecoderTest.cpp ../src/InitialPositionCodeDecoder.cpp gtest_main.o gtest-all.o -I../include
+-I../../googletest/googletest/include
+*/
+
+#include "InitialPositionCodeDecoder.h"
+#include <random>
+#include <gtest/gtest.h>
+
+namespace etrobocon2018_test {
+
+  // 初期値を返す
+  TEST(InitialPositionCodeDecoderTest, getInitialPositionCodeListTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    std::vector<std::int8_t> expected = {0, 0, 0, 0};
+
+    auto actual = obj.getInitialPositionCodeList();
+
+    ASSERT_EQ(expected, actual);
+  }
+
+  // パワーブロックの初期値を返す
+  TEST(InitialPositionCodeDecoderTest, getInitialPositionPowerBlockCodeTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    int8_t expected = 0;
+
+    auto actual = obj.getInitialPositionPowerBlockCode();
+
+    ASSERT_EQ(expected, actual);
+  }
+
+  // 0未満の引数に対して初期値を返す
+  TEST(InitialPositionCodeDecoderTest, returnInitialPositionCodeListByNegativeIntegerTest)
+  {
+    InitialPositionCodeDecoder obj;
+    std::vector<std::int8_t> expected = {0, 0, 0, 0};
+
+    obj.decode(-1);
+    auto actual = obj.getInitialPositionCodeList();
+
+    ASSERT_EQ(expected, actual);
+  }
+
+  // パワーブロックの初期位置コードをデコードする
+  TEST(InitialPositionCodeDecoderTest, decodePowerBlockCodeTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    std::int32_t codeList = 1;
+    int8_t expected = 1;
+
+    obj.decode(codeList);
+    auto actual = obj.getInitialPositionPowerBlockCode();
+
+    ASSERT_EQ(expected, actual);
+  }
+
+  // カラーブロックの初期位置コードの1番目をデコードする
+  TEST(InitialPositionCodeDecoderTest, decodeFirstColorBlockOfCodeTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    std::int32_t codeList = 65538;
+    std::vector<std::int8_t> expected = {1, 0, 0, 0};
+
+    obj.decode(codeList);
+    auto actual = obj.getInitialPositionCodeList();
+
+    ASSERT_EQ(expected.at(0), actual.at(0));
+  }
+
+  // カラーブロックの初期位置コードの2番目をデコードする
+  TEST(InitialPositionCodeDecoderTest, decodeSecondColorBlockOfCodeTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    std::int32_t codeList = 135171;
+    std::vector<std::int8_t> expected = {2, 1, 0, 0};
+
+    obj.decode(codeList);
+    auto actual = obj.getInitialPositionCodeList();
+
+    ASSERT_EQ(expected.at(1), actual.at(1));
+  }
+
+  // カラーブロックの初期位置コードの3番目をデコードする
+  TEST(InitialPositionCodeDecoderTest, decodeThirdColorBlockOfCodeTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    std::int32_t codeList = 205060;
+    std::vector<std::int8_t> expected = {3, 2, 1, 0};
+
+    obj.decode(codeList);
+    auto actual = obj.getInitialPositionCodeList();
+
+    ASSERT_EQ(expected.at(2), actual.at(2));
+  }
+
+  // カラーブロックの初期位置コードの4番目をデコードする
+  TEST(InitialPositionCodeDecoderTest, decodeFourthColorBlockOfCodeTest1)
+  {
+    InitialPositionCodeDecoder obj;
+    std::int32_t codeList = 274965;
+    std::vector<std::int8_t> expected = {4, 3, 2, 1};
+
+    obj.decode(codeList);
+    auto actual = obj.getInitialPositionCodeList();
+
+    ASSERT_EQ(expected.at(3), actual.at(3));
+  }
+
+  // ランダムの数値をデコードする
+  TEST(InitialPositionCodeDecoderTest, decodeRandomCodeTest)
+  {
+    InitialPositionCodeDecoder obj;
+
+    std::vector<std::int32_t> power16 = {1, 16, 16*16, 16*16*16, 16*16*16*16};
+    // 乱数を生成する
+    std::mt19937 mt{ std::random_device{}() };
+    // カラーブロックの乱数範囲を定める
+    std::uniform_int_distribution<std::int8_t> distC(1, 15);
+    // パワーブロックの乱数範囲を定める
+    std::uniform_int_distribution<std::int8_t> distP(1, 8);
+
+    for(int i = 0; i < 100; i++) {
+      std::vector<std::int8_t> expectedC = {distC(mt), distC(mt), distC(mt), distC(mt)};
+      std::int8_t expectedP = distP(mt);
+      std::int32_t expected =
+          expectedC[0] * power16[4] +
+          expectedC[1] * power16[3] +
+          expectedC[2] * power16[2] +
+          expectedC[3] * power16[1] +
+          expectedP * power16[0];
+
+      obj.decode(expected);
+      auto actual = obj.getInitialPositionCode();
+      auto actualC = obj.getInitialPositionCodeList();
+      auto actualP = obj.getInitialPositionPowerBlockCode();
+
+      EXPECT_EQ(expected, actual);
+      EXPECT_EQ(expectedC, actualC);
+      EXPECT_EQ(expectedP, actualP);
+    }
+  }
+
+}  // namespace etrobocon2018_test


### PR DESCRIPTION
# 変更点

初期位置コードをデコードし、 `std::vector<std::int8_t>` 型および `std::int8_t` 型に変換するクラスを作りました。

- ヘッダファイルを追加
- 実装ファイルを追加
- テストファイルを追加

# メリット

`std::int32_t` から簡単に初期位置コードを取得できます。

# その他

テストコードを書きましたが、カバレッジは未確認です。