### PR TITLE
clean: LightFilterをLPFに名前を変更した

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ file(GLOB SRC_FILES ${SOURCE_DIR}/Pid.cpp
     ${SOURCE_DIR}/InitialPositionCodeDecoder.cpp
     ${SOURCE_DIR}/Node.cpp
     ${SOURCE_DIR}/Explorer.cpp
-    ${SOURCE_DIR}/LightFilter.cpp
+    ${SOURCE_DIR}/LPF.cpp
     )
 add_library(${PROJECT_LIB_NAME} ${SRC_FILES})
 

--- a/str/Makefile.inc
+++ b/str/Makefile.inc
@@ -17,7 +17,7 @@ BasicWalker.o \
 Controller.o \
 Lifter.o \
 Distinguisher.o \
-LightFilter.o
+LPF.o
 
 ifeq ($(side),right)
     APPL_CXXOBJS += RightNormalCourse.o \

--- a/str/apps/include/LPF.h
+++ b/str/apps/include/LPF.h
@@ -1,21 +1,21 @@
 /**
- *  @file LightFilter.h
- *  @brief 光センサ値に用いるフィルタ処理をまとめたクラス
+ *  @file LPF.h
+ *  @brief LPF(Low-Pass Filter)をまとめたクラス
  *  @author T.Miyaji
  */
-#ifndef LIGHT_FILTER_H
-#define LIGHT_FILTER_H
+#ifndef LPF_H
+#define LPF_H
 #include <cstdint>
 
 /*!
- *  @class LightFilter
- *  @brief 光センサ値に用いるフィルタ処理をまとめたクラス
+ *  @class LPF
+ *  @brief LPF(Low-Pass Filter)をまとめたクラス
  */
-struct LightFilter {
+struct LPF {
   // 前回のセンサ値
   std::uint8_t pre_sensor;
   // コンストラクタ
-  LightFilter() : pre_sensor(0) { }
+  LPF() : pre_sensor(0) { }
   // 現在のセンサ値にフィルタ処理を実行する
   std::uint8_t sensor(std::uint8_t current_sensor);
   // RCフィルタ

--- a/str/apps/include/TurnControl.h
+++ b/str/apps/include/TurnControl.h
@@ -7,7 +7,7 @@
 #define __TURNCONTROL__
 
 #include "Pid.h"
-#include "LightFilter.h"
+#include "LPF.h"
 #include <cstdint>
 
 /**
@@ -24,7 +24,7 @@ class TurnControl : public Pid {
  private:
   double turn;
   double pid_value_old;
-  LightFilter filter;
+  LPF filter;
 };
 
 #endif

--- a/str/apps/src/LPF.cpp
+++ b/str/apps/src/LPF.cpp
@@ -1,14 +1,14 @@
-#include "LightFilter.h"
+#include "LPF.h"
 
 /**
- *  [LightFilter::sensor]
+ *  [LPF::sensor]
  *  @brief  現在のセンサ値にフィルタ処理を実行する
  *  @param  current_sensor 現在のセンサ値
  *  @return               フィルタ処理を実行したセンサ値
  */
-std::uint8_t LightFilter::sensor(std::uint8_t current_sensor)
+std::uint8_t LPF::sensor(std::uint8_t current_sensor)
 {
-  // presensorの初期化
+  // pre_sensorの初期化
   if(pre_sensor == 0){
     pre_sensor = current_sensor;
     return current_sensor;
@@ -19,12 +19,12 @@ std::uint8_t LightFilter::sensor(std::uint8_t current_sensor)
 }
 
 /**
- *  [LightFilter::RCFilter]
+ *  [LPF::RCFilter]
  *  @brief  RCフィルタ(ローパスフィルタ)処理
  *  @param  current_sensor 現在のセンサ値
  *  @return                フィルタ処理を実行したセンサ値
  */
-std::uint8_t LightFilter::RCFilter(std::uint8_t current_sensor)
+std::uint8_t LPF::RCFilter(std::uint8_t current_sensor)
 {
   // RCフィルタにおける係数(通常、0.8 or 0.9)
   constexpr double coefficient = 0.9;

--- a/str/apps/test/LPFTest.cpp
+++ b/str/apps/test/LPFTest.cpp
@@ -1,16 +1,16 @@
 /**
- *  @file LightFilterTest.cpp
+ *  @file LPFTest.cpp
  *  @author T.Miyaji
  */
 
-#include "LightFilter.h"
+#include "LPF.h"
 #include <gtest/gtest.h>
 
 namespace etrobocon2018_test {
 
-  TEST(LightFilter, sensorTest)
+  TEST(LPF, sensorTest)
   {
-    LightFilter filter;
+    LPF filter;
     std::uint8_t sensor = 24;  // This is 適当
 
     // 前回のセンサ値がない場合は、入力値をそのまま返す


### PR DESCRIPTION
# 変更点
LightFilterという名前をLPF(Low-Pass Filter)に変更しました。

# メリット
LPFとすることで、カラーセンサー以外でも使える汎用的なクラスになる（はず）。

# その他
名前を変更しただけです。