### PR TITLE
perf: Application is too Large問題の解決？

### DIFF
--- a/str/apps/src/Explorer.cpp
+++ b/str/apps/src/Explorer.cpp
@@ -45,17 +45,14 @@ void Explorer::resetBlockArea()
 
 void Explorer::setHasBlockIn(std::int8_t blockID)
 {
-  auto itr = blockAreaNodeList->begin();
-  for (int i = 0; i < blockID; i++) itr++;
+  auto itr = blockAreaNodeList->begin() + blockID;
   (*itr)->setHasBlock(true);
 }
 
 std::vector<int> Explorer::searchRoute(std::int8_t start, std::int8_t end)
 {
-  auto startItr = blockAreaNodeList->begin();
-  auto endItr = blockAreaNodeList->begin();
-  for (int i = 0; i < start; i++) startItr++;
-  for (int i = 0; i < end; i++) endItr++;
+  auto startItr = blockAreaNodeList->begin() + start;
+  auto endItr = blockAreaNodeList->begin() + end;
 
   int estimatedCostX = std::abs((*endItr)->getPositionX() - (*startItr)->getPositionX());
   int estimatedCostY = std::abs((*endItr)->getPositionY() - (*startItr)->getPositionY());
@@ -84,10 +81,8 @@ std::vector<int> Explorer::searchRoute(std::int8_t start, std::int8_t end)
 
 Node* Explorer::calculateNeighborCost(Node* parent, std::vector<Node*>* around, std::int32_t realCost, std::int8_t end)
 {
-  auto currentItr = blockAreaNodeList->begin();
-  auto endItr = blockAreaNodeList->begin();
-  for (int i = 0; i < parent->getNodeID(); i++) currentItr++;
-  for (int i = 0; i < end; i++) endItr++;
+  auto currentItr = blockAreaNodeList->begin() + parent->getNodeID();
+  auto endItr = blockAreaNodeList->begin() + end;
 
   parent->setBeClosed(true);
 

--- a/str/apps/src/Explorer.cpp
+++ b/str/apps/src/Explorer.cpp
@@ -33,34 +33,41 @@ void Explorer::createBlockArea()
 
 void Explorer::resetBlockArea()
 {
-  for (unsigned int i = 0; i < blockAreaNodeList->size(); i++)
+  for (auto itr = blockAreaNodeList->begin(); itr != blockAreaNodeList->end(); itr++)
   {
-    blockAreaNodeList->at(i)->setBeClosed(false);
-    blockAreaNodeList->at(i)->setHasBlock(false);
-    blockAreaNodeList->at(i)->setScore(0);
-    blockAreaNodeList->at(i)->setRealCost(0);
-    blockAreaNodeList->at(i)->setParentNode(nullptr);
+    (*itr)->setBeClosed(false);
+    (*itr)->setHasBlock(false);
+    (*itr)->setScore(0);
+    (*itr)->setRealCost(0);
+    (*itr)->setParentNode(nullptr);
   }
 }
 
 void Explorer::setHasBlockIn(std::int8_t blockID)
 {
-  blockAreaNodeList->at(blockID)->setHasBlock(true);
+  auto itr = blockAreaNodeList->begin();
+  for (int i = 0; i < blockID; i++) itr++;
+  (*itr)->setHasBlock(true);
 }
 
 std::vector<int> Explorer::searchRoute(std::int8_t start, std::int8_t end)
 {
-  int estimatedCostX = std::abs(blockAreaNodeList->at(end)->getPositionX() - blockAreaNodeList->at(start)->getPositionX());
-  int estimatedCostY = std::abs(blockAreaNodeList->at(end)->getPositionY() - blockAreaNodeList->at(start)->getPositionY());
-  int score = estimatedCostX + estimatedCostY;
-  if (blockAreaNodeList->at(start)->hasBlock()) score += 99;
+  auto startItr = blockAreaNodeList->begin();
+  auto endItr = blockAreaNodeList->begin();
+  for (int i = 0; i < start; i++) startItr++;
+  for (int i = 0; i < end; i++) endItr++;
 
-  blockAreaNodeList->at(start)->setScore(score);
-  blockAreaNodeList->at(start)->setRealCost(0);
-  blockAreaNodeList->at(start)->setParentNode(nullptr);
+  int estimatedCostX = std::abs((*endItr)->getPositionX() - (*startItr)->getPositionX());
+  int estimatedCostY = std::abs((*endItr)->getPositionY() - (*startItr)->getPositionY());
+  int score = estimatedCostX + estimatedCostY;
+  if ((*startItr)->hasBlock()) score += 99;
+
+  (*startItr)->setScore(score);
+  (*startItr)->setRealCost(0);
+  (*startItr)->setParentNode(nullptr);
 
   std::vector<Node*> around;
-  Node* endNode = calculateNeighborCost(blockAreaNodeList->at(start), &around, 1, end);
+  Node* endNode = calculateNeighborCost((*startItr), &around, 1, end);
 
   std::vector<int> route = {endNode->getNodeID()};
   Node* parent = endNode->getParentNode();
@@ -77,42 +84,42 @@ std::vector<int> Explorer::searchRoute(std::int8_t start, std::int8_t end)
 
 Node* Explorer::calculateNeighborCost(Node* parent, std::vector<Node*>* around, std::int32_t realCost, std::int8_t end)
 {
-  std::int8_t current = parent->getNodeID();
+  auto currentItr = blockAreaNodeList->begin();
+  auto endItr = blockAreaNodeList->begin();
+  for (int i = 0; i < parent->getNodeID(); i++) currentItr++;
+  for (int i = 0; i < end; i++) endItr++;
+
   parent->setBeClosed(true);
 
-  for (unsigned int i = 0; i < blockAreaNodeList->at(current)->getNeighbors()->size(); i++)
-  // for (auto neighbor : blockAreaNodeList->at(parent->getNodeID())->getNeighbors())
+  for (auto itr = (*currentItr)->getNeighbors()->begin(); itr != (*currentItr)->getNeighbors()->end(); itr++)
   {
-    auto neighbor = blockAreaNodeList->at(current)->getNeighbors()->at(i);
-    if (neighbor->isClosed() || neighbor == parent->getParentNode()) continue;
+    if ((*itr)->isClosed() || (*itr) == parent->getParentNode()) continue;
 
-    int estimatedCostX = std::abs(blockAreaNodeList->at(end)->getPositionX() - neighbor->getPositionX());
-    int estimatedCostY = std::abs(blockAreaNodeList->at(end)->getPositionY() - neighbor->getPositionY());
+    int estimatedCostX = std::abs((*endItr)->getPositionX() - (*itr)->getPositionX());
+    int estimatedCostY = std::abs((*endItr)->getPositionY() - (*itr)->getPositionY());
     int score = realCost + estimatedCostX + estimatedCostY;
-    if (neighbor->hasBlock() && neighbor->getNodeID() != end) score += 99;
+    if ((*itr)->hasBlock() && (*itr)->getNodeID() != end) score += 99;
 
-    neighbor->setScore(score);
-    neighbor->setRealCost(realCost);
-    neighbor->setParentNode(parent);
-    around->push_back(neighbor);
+    (*itr)->setScore(score);
+    (*itr)->setRealCost(realCost);
+    (*itr)->setParentNode(parent);
+    around->push_back((*itr));
   }
 
   std::int32_t min = 999;
   std::int32_t minCost = 999;
   Node* minNode = nullptr;
 
-  for (unsigned int i = 0; i < around->size(); i++)
-  // for (auto neighbor : blockAreaNodeList->at(parent->getNodeID())->getNeighbors())
+  for (auto itr = around->begin(); itr != around->end(); itr++)
   {
-    auto neighborhood = around->at(i);
-    if (neighborhood->isClosed() || neighborhood == parent->getParentNode()) continue;
+    if ((*itr)->isClosed() || (*itr) == parent->getParentNode()) continue;
 
-    int score = neighborhood->getScore();
-    if (score > min || (score == min && neighborhood->getRealCost() >= minCost)) continue;
+    int score = (*itr)->getScore();
+    if (score > min || (score == min && (*itr)->getRealCost() >= minCost)) continue;
 
     min = score;
-    minCost = neighborhood->getRealCost();
-    minNode = neighborhood;
+    minCost = (*itr)->getRealCost();
+    minNode = (*itr);
   }
 
   if (minNode->getNodeID() != end)


### PR DESCRIPTION
# 変更点

`std::vector` クラスにおける `at` 関数を利用せず、 `begin` 関数を利用して要素を取得するようにしました。

# メリット

`at` 関数内のtry-catch文を無視することで、省メモリ化ができました。

# その他

回帰テストは全てパスしました。

実装提案はTamiyas氏です。
`at` 関数利用時の容量は6,500,000バイトほど、非利用時の容量は650,000バイト台です。
実機を用いたテストは行っておりません。